### PR TITLE
fix Display Cutout issue on Android 10 and above

### DIFF
--- a/base-kmp/src/commonMain/kotlin/com/funny/translation/ui/CommonComposables.kt
+++ b/base-kmp/src/commonMain/kotlin/com/funny/translation/ui/CommonComposables.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyListScope
@@ -59,7 +58,7 @@ fun CommonPage(
     Column(
         modifier
             .fillMaxSize()
-            .statusBarsPadding(),
+            .windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top)),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         topBar()
@@ -143,9 +142,7 @@ fun CommonNavBackIcon(
 @Composable
 fun NavPaddingItem() {
     if (currentPlatform == Platform.Android) {
-        Spacer(modifier = Modifier.windowInsetsPadding(
-            WindowInsets.navigationBars.only(WindowInsetsSides.Vertical))
-        )
+        Spacer(modifier = Modifier.windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.Bottom)))
     } else {
         // add some padding for Desktop
         Spacer(modifier = Modifier.height(8.dp))

--- a/base-kmp/src/commonMain/kotlin/com/funny/translation/ui/WindowInsetsEx.kt
+++ b/base-kmp/src/commonMain/kotlin/com/funny/translation/ui/WindowInsetsEx.kt
@@ -1,0 +1,21 @@
+package com.funny.translation.ui
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.union
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.ui.Modifier
+
+/**
+ * WindowInsets.safeDrawing, Exclude ime
+ */
+val WindowInsets.Companion.safeMain: WindowInsets
+    @Composable
+    @NonRestartableComposable
+    get() = WindowInsets.systemBars.union(WindowInsets.displayCutout)
+
+@Composable
+fun Modifier.safeMainPadding() = windowInsetsPadding(WindowInsets.safeMain)

--- a/composeApp/src/androidMain/res/values-v23/styles.xml
+++ b/composeApp/src/androidMain/res/values-v23/styles.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <style name="AppTheme" parent="BaseTheme">
-        <item name="android:windowLightStatusBar">false</item>
-    </style>
-</resources>

--- a/composeApp/src/androidMain/res/values-v27/styles.xml
+++ b/composeApp/src/androidMain/res/values-v27/styles.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="AppTheme" parent="BaseTheme">
-        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
-        <item name="android:navigationBarDividerColor">#00000000</item>
-    </style>
-</resources>

--- a/composeApp/src/androidMain/res/values-v29/styles.xml
+++ b/composeApp/src/androidMain/res/values-v29/styles.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="AppTheme" parent="BaseTheme">
-        <item name="android:forceDarkAllowed">false</item>
-        <item name="android:enforceNavigationBarContrast">false</item>
-        <item name="android:navigationBarDividerColor">#00000000</item>
-    </style>
-</resources>

--- a/composeApp/src/androidMain/res/values/styles.xml
+++ b/composeApp/src/androidMain/res/values/styles.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources>
+<resources xmlns:tools="http://schemas.android.com/tools">
 <!--    <style name="AppTheme" parent="android:Theme.DeviceDefault.Light.NoActionBar.Fullscreen">-->
 <!--    </style>-->
     <style name="BaseTheme" parent="Theme.AppCompat.DayNight.NoActionBar">
@@ -9,7 +9,11 @@
     </style>
 
     <style name="AppTheme" parent="BaseTheme">
-
+        <item name="android:windowLightStatusBar">false</item>
+        <item name="android:windowLayoutInDisplayCutoutMode" tools:targetApi="o_mr1">shortEdges</item>
+        <item name="android:navigationBarDividerColor" tools:targetApi="o_mr1">#00000000</item>
+        <item name="android:forceDarkAllowed" tools:targetApi="q">false</item>
+        <item name="android:enforceNavigationBarContrast" tools:targetApi="q">false</item>
     </style>
 
     <style name="AppTheme.NoActionBar" parent="Theme.AppCompat.DayNight.NoActionBar">

--- a/composeApp/src/commonMain/kotlin/com/funny/translation/translate/AppNavigation.kt
+++ b/composeApp/src/commonMain/kotlin/com/funny/translation/translate/AppNavigation.kt
@@ -56,6 +56,7 @@ import com.funny.translation.translate.ui.long_text.TextEditorScreen
 import com.funny.translation.translate.ui.main.FavoriteScreen
 import com.funny.translation.translate.ui.main.ImageTransScreen
 import com.funny.translation.translate.ui.main.MainScreen
+import com.funny.translation.translate.ui.main.ProvideWindowSizeState
 import com.funny.translation.translate.ui.plugin.PluginScreen
 import com.funny.translation.translate.ui.settings.AboutScreen
 import com.funny.translation.translate.ui.settings.FloatWindowScreen
@@ -127,22 +128,23 @@ fun AppNavigation(
                 SnackbarHost(hostState = snackbarHostState)
             }
         ) { scaffoldPadding ->
-            NavHost(
-                navController = navController,
-                startDestination = TranslateScreen.MainScreen.route,
-                modifier = Modifier.fillMaxSize(),
-            ) {
-                composable(
-                    TranslateScreen.MainScreen.route,
+            ProvideWindowSizeState {
+                NavHost(
+                    navController = navController,
+                    startDestination = TranslateScreen.MainScreen.route,
+                    modifier = Modifier.fillMaxSize(),
                 ) {
-                    MainScreen()
-                }
-                animateComposable(
-                    TranslateScreen.ImageTranslateScreen.route,
-                    deepLinks = listOf(
-                        "${DeepLinkManager.PREFIX}${DeepLinkManager.IMAGE_TRANS_PATH}?imageUri={imageUri}&sourceId={sourceId}&targetId={targetId}&doClip={doClip}".removeQuery()
-                    ),
-                    arguments = listOf(
+                    composable(
+                        TranslateScreen.MainScreen.route,
+                    ) {
+                        MainScreen()
+                    }
+                    animateComposable(
+                        TranslateScreen.ImageTranslateScreen.route,
+                        deepLinks = listOf(
+                            "${DeepLinkManager.PREFIX}${DeepLinkManager.IMAGE_TRANS_PATH}?imageUri={imageUri}&sourceId={sourceId}&targetId={targetId}&doClip={doClip}".removeQuery()
+                        ),
+                        arguments = listOf(
 //                            navArgument("imageUri") {
 //                                type = NavType.StringType; defaultValue = null; nullable = true
 //                            },
@@ -155,89 +157,90 @@ fun AppNavigation(
 //                            navArgument("doClip") {
 //                                type = NavType.BoolType; defaultValue = false
 //                            }
-                    )
-                ) { backStackEntry ->
-                    // 使用 Intent 跳转目前会导致 Activity 重建
-                    // 不合理，相当不合理
-                    ImageTransScreen(
-                        imageUri = backStackEntry.getQueryString("imageUri")?.let { Uri.parse(it) },
-                        sourceId = backStackEntry.getQueryInt("sourceId"),
-                        targetId = backStackEntry.getQueryInt("targetId"),
-                        doClipFirst = backStackEntry.getQueryBoolean("doClip", false)
-                    )
-                }
-                animateComposable(TranslateScreen.AboutScreen.route) {
-                    AboutScreen()
-                }
-                animateComposable(TranslateScreen.PluginScreen.route) {
-                    PluginScreen()
-                }
-                animateComposable(TranslateScreen.TransProScreen.route) {
-                    TransProScreen()
-                }
-                animateComposable(TranslateScreen.ThanksScreen.route) {
-                    ThanksScreen()
-                }
-                animateComposable(TranslateScreen.FloatWindowScreen.route) {
-                    FloatWindowScreen()
-                }
-                animateComposable(TranslateScreen.FavoriteScreen.route) {
-                    FavoriteScreen()
-                }
-                animateComposable(TranslateScreen.AppRecommendationScreen.route) {
-                    AppRecommendationScreen()
-                }
-                val animDuration = NAV_ANIM_DURATION
-                composable(
-                    TranslateScreen.ChatScreen.route,
-                    enterTransition = {
-                        slideIntoContainer(
-                            AnimatedContentTransitionScope.SlideDirection.Up,
-                            animationSpec = tween(animDuration)
                         )
-                    },
-                    exitTransition = {
-                        slideOutOfContainer(
-                            AnimatedContentTransitionScope.SlideDirection.Up,
-                            animationSpec = tween(animDuration)
-                        )
-                    },
-                    popEnterTransition = {
-                        slideIntoContainer(
-                            AnimatedContentTransitionScope.SlideDirection.Down,
-                            animationSpec = tween(animDuration)
-                        )
-                    },
-                    popExitTransition = {
-                        slideOutOfContainer(
-                            AnimatedContentTransitionScope.SlideDirection.Down,
-                            animationSpec = tween(animDuration)
+                    ) { backStackEntry ->
+                        // 使用 Intent 跳转目前会导致 Activity 重建
+                        // 不合理，相当不合理
+                        ImageTransScreen(
+                            imageUri = backStackEntry.getQueryString("imageUri")?.let { Uri.parse(it) },
+                            sourceId = backStackEntry.getQueryInt("sourceId"),
+                            targetId = backStackEntry.getQueryInt("targetId"),
+                            doClipFirst = backStackEntry.getQueryBoolean("doClip", false)
                         )
                     }
-                ) {
-                    ChatScreen()
-                }
-                animateComposable(
-                    TranslateScreen.BuyAIPointScreen.route.removeQuery(),
+                    animateComposable(TranslateScreen.AboutScreen.route) {
+                        AboutScreen()
+                    }
+                    animateComposable(TranslateScreen.PluginScreen.route) {
+                        PluginScreen()
+                    }
+                    animateComposable(TranslateScreen.TransProScreen.route) {
+                        TransProScreen()
+                    }
+                    animateComposable(TranslateScreen.ThanksScreen.route) {
+                        ThanksScreen()
+                    }
+                    animateComposable(TranslateScreen.FloatWindowScreen.route) {
+                        FloatWindowScreen()
+                    }
+                    animateComposable(TranslateScreen.FavoriteScreen.route) {
+                        FavoriteScreen()
+                    }
+                    animateComposable(TranslateScreen.AppRecommendationScreen.route) {
+                        AppRecommendationScreen()
+                    }
+                    val animDuration = NAV_ANIM_DURATION
+                    composable(
+                        TranslateScreen.ChatScreen.route,
+                        enterTransition = {
+                            slideIntoContainer(
+                                AnimatedContentTransitionScope.SlideDirection.Up,
+                                animationSpec = tween(animDuration)
+                            )
+                        },
+                        exitTransition = {
+                            slideOutOfContainer(
+                                AnimatedContentTransitionScope.SlideDirection.Up,
+                                animationSpec = tween(animDuration)
+                            )
+                        },
+                        popEnterTransition = {
+                            slideIntoContainer(
+                                AnimatedContentTransitionScope.SlideDirection.Down,
+                                animationSpec = tween(animDuration)
+                            )
+                        },
+                        popExitTransition = {
+                            slideOutOfContainer(
+                                AnimatedContentTransitionScope.SlideDirection.Down,
+                                animationSpec = tween(animDuration)
+                            )
+                        }
+                    ) {
+                        ChatScreen()
+                    }
+                    animateComposable(
+                        TranslateScreen.BuyAIPointScreen.route.removeQuery(),
 //                        arguments = listOf(
 //                            navArgument("planName") {
 //                                type = NavType.StringType; defaultValue = null; nullable = true
 //                            }
 //                        )
-                ) {
-                    val planName = it.getQueryString("planName")
-                    BuyAIPointScreen(planName ?: AI_TEXT_POINT)
-                }
-                animateComposable(TranslateScreen.AnnualReportScreen.route) {
-                    AnnualReportScreen()
-                }
-                addLongTextTransNavigation()
-                addSettingsNavigation()
-                addUserProfileRoutes(
-                    navHostController = navController
-                ) { userBean ->
-                    Log.d(TAG, "登录成功: 用户: $userBean")
-                    if (userBean.isValid()) AppConfig.login(userBean, updateVipFeatures = true)
+                    ) {
+                        val planName = it.getQueryString("planName")
+                        BuyAIPointScreen(planName ?: AI_TEXT_POINT)
+                    }
+                    animateComposable(TranslateScreen.AnnualReportScreen.route) {
+                        AnnualReportScreen()
+                    }
+                    addLongTextTransNavigation()
+                    addSettingsNavigation()
+                    addUserProfileRoutes(
+                        navHostController = navController
+                    ) { userBean ->
+                        Log.d(TAG, "登录成功: 用户: $userBean")
+                        if (userBean.isValid()) AppConfig.login(userBean, updateVipFeatures = true)
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/MainPartInputting.kt
+++ b/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/MainPartInputting.kt
@@ -9,12 +9,15 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.imePadding
-import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.ElevatedButton
@@ -91,29 +94,45 @@ fun MainPartInputting(
     }
     BackHandler(onBack = goBackAction)
     Column(
-        Modifier
+        modifier = Modifier
             .fillMaxSize()
-            .background(MaterialTheme.colorScheme.primaryContainer)
-            .navigationBarsPadding()
-            .imePadding(),
+            .background(MaterialTheme.colorScheme.primaryContainer),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        UpperPartBackground(modifier = Modifier.weight(1f)) {
-            MainTopBarInputting(
-                showEngineSelectAction = showEngineSelectAction,
-                navigateBackAction = goBackAction
-            )
-            InputPart(
+        UpperPartBackground(
+            modifier = Modifier.weight(1f)
+        ) {
+            Column(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                vm = vm,
-                startTranslateActon = ::startTranslate
-            )
+                    .run {
+                        when (LocalWindowSizeState.current) {
+                            WindowSizeState.VERTICAL -> windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal))
+                            WindowSizeState.HORIZONTAL -> windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Top + WindowInsetsSides.End))
+                    }
+                }
+            ) {
+                MainTopBarInputting(
+                    showEngineSelectAction = showEngineSelectAction,
+                    navigateBackAction = goBackAction
+                )
+                InputPart(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                    vm = vm,
+                    startTranslateActon = ::startTranslate
+                )
+            }
         }
         LanguageSelectRow(
             modifier = Modifier
                 .fillMaxWidth()
+                .run {
+                    when (LocalWindowSizeState.current) {
+                        WindowSizeState.VERTICAL -> windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal))
+                        WindowSizeState.HORIZONTAL -> windowInsetsPadding(WindowInsets.safeDrawing.only(WindowInsetsSides.Bottom + WindowInsetsSides.End))
+                    }
+                }
                 .padding(horizontal = 20.dp, vertical = 12.dp),
             sourceLanguage = vm.sourceLanguage,
             updateSourceLanguage = vm::updateSourceLanguage,

--- a/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/MainPartNormal.kt
+++ b/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/MainPartNormal.kt
@@ -397,7 +397,7 @@ private fun ChildrenFixedSizeRow(
             constraints.copy(minWidth = 0)
         )
         val centerWidth = centerPlaceable.width
-        val w = ((allWidth - centerWidth - 2 * ep) / 2)
+        val w = ((allWidth - centerWidth - 2 * ep) / 2).coerceAtLeast(0)
         val leftPlaceable = subcompose("left", left).first().measure(
             constraints.copy(minWidth = w, maxWidth = w)
         )

--- a/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/MainPartNormal.kt
+++ b/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/MainPartNormal.kt
@@ -14,12 +14,16 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -91,6 +95,8 @@ import com.funny.translation.translate.ui.widget.SwipeCrossFadeLayout
 import com.funny.translation.translate.ui.widget.SwipeShowType
 import com.funny.translation.translate.ui.widget.UpperPartBackground
 import com.funny.translation.ui.FixedSizeIcon
+import com.funny.translation.ui.safeMain
+import com.funny.translation.ui.safeMainPadding
 import com.funny.translation.ui.touchToScale
 import kotlinx.coroutines.launch
 import moe.tlaster.precompose.lifecycle.Lifecycle
@@ -168,21 +174,38 @@ internal fun MainPartNormal(
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.primaryContainer),
         onProgressChanged = { progressState.floatValue = it },
-
         mainUpper = {
             UpperPartBackground {
-                MainTopBarNormal(showDrawerAction = openDrawerAction)
-                Notice(Modifier.fillMaxWidth(0.9f))
-                Spacer(modifier = Modifier.height(8.dp))
-                HintText(
-                    onClick = { vm.updateMainScreenState(MainScreenState.Inputting) },
-                    onLongClick = vm::tryToPasteAndTranslate
-                )
+                Column(
+                    modifier = Modifier
+                        .run {
+                            when (LocalWindowSizeState.current) {
+                                WindowSizeState.VERTICAL -> windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.Top + WindowInsetsSides.Horizontal))
+                                WindowSizeState.HORIZONTAL -> windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.Top + WindowInsetsSides.End))
+                            }
+                        },
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    MainTopBarNormal(showDrawerAction = openDrawerAction)
+                    Notice(Modifier.fillMaxWidth(0.9f))
+                    Spacer(modifier = Modifier.height(8.dp))
+                    HintText(
+                        onClick = { vm.updateMainScreenState(MainScreenState.Inputting) },
+                        onLongClick = vm::tryToPasteAndTranslate
+                    )
+                }
             }
         },
         mainLower = {
             Column(
-                Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .run {
+                        when (LocalWindowSizeState.current) {
+                            WindowSizeState.VERTICAL -> windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal))
+                            WindowSizeState.HORIZONTAL -> windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.Bottom + WindowInsetsSides.End))
+                        }
+                    },
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Spacer(modifier = Modifier.height(8.dp))
@@ -203,7 +226,7 @@ internal fun MainPartNormal(
                             start = 24.dp,
                             end = 24.dp,
                             top = 8.dp,
-                            bottom = if (isScreenHorizontal) 8.dp else 52.dp
+                            bottom = if (isScreenHorizontal) 8.dp else 24.dp
                         ),
                     showEngineSelectAction
                 )

--- a/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/MainPartTranslating.kt
+++ b/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/MainPartTranslating.kt
@@ -13,12 +13,18 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.CircleShape
@@ -83,6 +89,7 @@ import com.funny.translation.ui.CommonPage
 import com.funny.translation.ui.FixedSizeIcon
 import com.funny.translation.ui.MarkdownText
 import com.funny.translation.ui.NavPaddingItem
+import com.funny.translation.ui.safeMain
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -114,24 +121,42 @@ fun MainPartTranslating(vm: MainViewModel) {
     }
 
     BackHandler(onBack = goBack)
-    CommonPage(
-        navigationIcon = {
-            CommonNavBackIcon(navigateBackAction = goBack)
-        }
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .run {
+                when (LocalWindowSizeState.current) {
+                    WindowSizeState.VERTICAL -> windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top))
+                    WindowSizeState.HORIZONTAL -> windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.End + WindowInsetsSides.Top))
+                }
+            }
     ) {
-        TranslateProgress(startedProgress = vm.startedProgress, finishedProgress = vm.finishedProgress)
-        SourceTextPart(
-            modifier = Modifier.fillMaxWidth(0.88f),
-            sourceText = vm.translateText,
-            sourceLanguage = vm.sourceLanguage
-        )
-        Spacer(modifier = Modifier.height(8.dp))
-        ResultList(
+        CommonNavBackIcon(navigateBackAction = goBack)
+        Column(
             modifier = Modifier
-                .fillMaxSize(),
-            resultList = vm.resultList,
-            doFavorite = vm::doFavorite
-        )
+                .fillMaxSize()
+                .run {
+                    when (LocalWindowSizeState.current) {
+                        WindowSizeState.VERTICAL -> windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.Horizontal))
+                        WindowSizeState.HORIZONTAL -> windowInsetsPadding(WindowInsets.safeMain.only(WindowInsetsSides.End))
+                    }
+                },
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            TranslateProgress(startedProgress = vm.startedProgress, finishedProgress = vm.finishedProgress)
+            SourceTextPart(
+                modifier = Modifier.fillMaxWidth(0.88f),
+                sourceText = vm.translateText,
+                sourceLanguage = vm.sourceLanguage
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            ResultList(
+                modifier = Modifier
+                    .fillMaxSize(),
+                resultList = vm.resultList,
+                doFavorite = vm::doFavorite
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/WindowSizeState.kt
+++ b/composeApp/src/commonMain/kotlin/com/funny/translation/translate/ui/main/WindowSizeState.kt
@@ -1,0 +1,48 @@
+package com.funny.translation.translate.ui.main
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+val LocalWindowSizeState = compositionLocalOf<WindowSizeState> {
+    error("LocalWindowSizeState not initialized")
+}
+
+/**
+ * 窗口大小状态
+ */
+enum class WindowSizeState {
+
+    /**
+     * 垂直状态
+     */
+    VERTICAL,
+
+    /**
+     * 水平状态
+     */
+    HORIZONTAL
+
+}
+
+@Composable
+fun ProvideWindowSizeState(
+    content: @Composable () -> Unit
+) {
+    BoxWithConstraints(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        CompositionLocalProvider(
+            value = LocalWindowSizeState provides when {
+                maxWidth > 720.dp -> WindowSizeState.HORIZONTAL
+                else -> WindowSizeState.VERTICAL
+            },
+            content = content
+        )
+    }
+}


### PR DESCRIPTION
The higher version theme v29 will completely cover the lower version theme v27, so there is still a Display Cutout issue on v29 and above. Removed v23/v27/v29 themes and unified them in values/styles.XML for easy management.